### PR TITLE
Correction for stopping loaded gcode file to start to run after probing

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1,3 +1,4 @@
+// Mofified
 $(function() {
 
 const MACHINE_STALL = 0;
@@ -926,7 +927,11 @@ controller.on('gcode:load', function(name, gcode) {
 
 controller.on('workflow:state', function(state) {
     switch(state) {
-    case 'idle': cnc.line = 0; break;
+    case 'idle': 
+     cnc.line = 0;
+     // Stop the probing: correct if not stopped the following load of a gcode file will start to run at loading
+     probing=false; 
+     break;
     case 'paused': break;
     case 'running': break;
     }


### PR DESCRIPTION
Hi,

As we discuss and after much delay for one small change here's my correction to stop the automatic start of gcode file loaded after a probing.

